### PR TITLE
add URL tag option to the options

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,13 @@ relocated by the user at install time.  The manual entry for the
 [prefix tag](http://www.rpm.org/max-rpm/s1-rpm-reloc-prefix-tag.html) explains
 the use case quite well.
 
+#### options.url
+Type: `String`
+Default Value: `""`
+
+A URL to the project homepage or documentation of the project. Defined in the
+[spec-file specification](http://www.rpm.org/wiki/PackagerDocs/Spec#URL:andPackager:Tags).
+
 #### options.dependencies
 Type: `Array<String>`
 Default value: `[]`

--- a/tasks/easy_rpm.js
+++ b/tasks/easy_rpm.js
@@ -34,6 +34,7 @@ function writeSpecFile(grunt, files, attrs, options) {
     b.push("Version: " + options.version);
     b.push("Release: " + options.release);
     b.push("Group: " + options.group);
+    b.push("URL: " + options.url);
     b.push("Summary: " + options.summary);
     b.push("Group: " + options.group);
     b.push("License: " + options.license);
@@ -125,6 +126,7 @@ module.exports = function(grunt) {
                 version: "0.1.0",
                 release: "1",
                 license: "MIT",
+                url: "",
                 vendor: "Vendor",
                 group: "Development/Tools",
                 buildArch: "noarch",


### PR DESCRIPTION
 Fixes `no-url-tag` warning produced by `rpmlint`

Thanks!
