### PR TITLE
Fix autoReq and autoProv

### DIFF
--- a/tasks/easy_rpm.js
+++ b/tasks/easy_rpm.js
@@ -148,8 +148,12 @@ function applySpecSettings(grunt, options, spec) {
         spec.addRequirements.apply(spec, options.requires);
     }
 
-    spec.tags.autoReq = options.autoReq || spec.tags.autoReq;
-    spec.tags.autoProv = options.autoProv || spec.tags.autoProv;
+    if (options.autoReq == false) {
+        spec.tags.autoReq = options.autoReq;
+    }
+    if (options.autoProv == false) {
+        spec.tags.autoProv = options.autoProv;
+    }
 
     if (options.hasOwnProperty('excludeArchs')) {
         spec.addExcludeArchs.apply(spec, options.excludeArchs);

--- a/tasks/easy_rpm.js
+++ b/tasks/easy_rpm.js
@@ -148,10 +148,10 @@ function applySpecSettings(grunt, options, spec) {
         spec.addRequirements.apply(spec, options.requires);
     }
 
-    if (options.autoReq == false) {
+    if (options.autoReq === false) {
         spec.tags.autoReq = options.autoReq;
     }
-    if (options.autoProv == false) {
+    if (options.autoProv === false) {
         spec.tags.autoProv = options.autoProv;
     }
 


### PR DESCRIPTION
autoReq and autoProv default to true, and we only override them to false in Grunt config files. There for, options.autoReq will evaluate to false, and leave spec.tags.autoReq as true. This fixes them so we can actually override autoReq and autoProv