### PR TITLE
Pass _topdir as command line parameter instead of directive in spec

### DIFF
--- a/tasks/easy_rpm.js
+++ b/tasks/easy_rpm.js
@@ -267,11 +267,6 @@ module.exports = function(grunt) {
         tmpDir = path.resolve(options.tempDir);
         buildRoot = path.resolve(tmpDir + "/BUILDROOT/");
 
-        // In order to build out the RPM into our specified directory, we
-        // must append a %define directive to the spec that indicates where
-        // the top level of the build is.
-        spec.addDefines('_topdir ' + tmpDir);
-
         // Assign the options to the spec file object.
         applySpecSettings(grunt, options, spec);
 
@@ -392,8 +387,15 @@ module.exports = function(grunt) {
 
         // Spawn rpmbuild tool.
         var buildCmd = 'rpmbuild';
+
         var buildArgs = [
             '-bb',
+
+            // In order to build out the RPM into our specified directory, we
+            // must append a --define directive to rpmbuild that indicates where
+            // the top level of the build is.
+            '--define',
+            '_topdir ' + tmpDir,
             '-vv',
             '--buildroot',
             buildRoot,


### PR DESCRIPTION
When you define _topdir in the spec file instead of the command line, rpmbuild creates a directory `rpmbuild` in the user's home which doesn't get deleted afterwards. This is easily reproducible.