### PR TITLE
autoReq and autoProv options do not work when set to false

### DIFF
--- a/tasks/easy_rpm.js
+++ b/tasks/easy_rpm.js
@@ -147,10 +147,12 @@ function applySpecSettings(grunt, options, spec) {
     if (_.has(options, 'requires')) {
         spec.addRequirements.apply(spec, options.requires);
     }
-
-    spec.tags.autoReq = options.autoReq || spec.tags.autoReq;
-    spec.tags.autoProv = options.autoProv || spec.tags.autoProv;
-
+    if (_.has(options, 'autoReq')) {
+        spec.tags.autoReq = options.autoReq;
+    }
+    if (_.has(options, 'autoProv')) {
+        spec.tags.autoProv = options.autoProv;
+    }
     if (options.hasOwnProperty('excludeArchs')) {
         spec.addExcludeArchs.apply(spec, options.excludeArchs);
     }


### PR DESCRIPTION
Due to a logic error in the code, setting autoReq and autoProv to false on the Gruntfile results in these options being overwritten with their default, which is true.  This code change addresses that issue.