### PR TITLE
Support Requires(scriptlet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,10 +405,12 @@ Will add the following to the SPEC file:
 ```
 
 ### requires
-`Array<String>`
+`Array<String|Object>`
 
 An array of packages that this package depends on (e.g.
-`["nodejs >= 0.10.22", "libpng"]`).
+`["nodejs >= 0.10.22", "libpng"]`). Can also include an object
+to map dependencies for scriptlets, e.g.
+`["nodejs >= 0.10.22", {"post": ["%{systemd_post_requires}"]}]`
 
 ### provides
 `Array<String>`

--- a/tasks/lib/spec-writer.js
+++ b/tasks/lib/spec-writer.js
@@ -148,7 +148,20 @@ module.exports = function(spec, callback) {
     bufferTagIfExists(buffer, spec, 'packager', 'Packager');
 
     if (spec.tags.requires.length > 0) {
-        buffer.add('Requires: ' + spec.tags.requires.join(', '));
+        plainRequires = spec.tags.requires.filter(function(require) {
+            switch(typeof require) {
+                case 'string':
+                    return true;
+                case 'object':
+                    Object.keys(require).map(function(key) {
+                        buffer.add('Requires(' + key + '): ' + require[key].join(', '));
+                    });
+                    return false;
+                default:
+                    return false;
+            }
+        });
+        buffer.add('Requires: ' + plainRequires.join(', '));
     }
     if (spec.tags.provides.length > 0) {
         buffer.add('Provides: ' + spec.tags.provides.join(', '));

--- a/test/spec-writer.js
+++ b/test/spec-writer.js
@@ -84,6 +84,7 @@ describe('spec writer', function() {
             spec.tags.autoReq = false;
             spec.tags.autoProv = false;
             spec.addRequirements('quux > 1.6.9', 'k9 <= 2.0');
+            spec.tags.requires.push({'foo': ['bar = 1.2.3']});
             spec.addProvides('virtualeasyrpm = 0.0.1');
             spec.addConflicts('quux = 1.6.9', 'baz < 1.2');
             spec.addExcludeArchs('sparc', 'alpha');

--- a/test/spec_writer_expected/expect_05.spec
+++ b/test/spec_writer_expected/expect_05.spec
@@ -11,6 +11,7 @@ Vendor: EasyRPM Inc.
 URL: http://www.google.com/
 Group: Applications/Productivity
 Packager: Dr. Foo <foo@tardis.com>
+Requires(foo): bar = 1.2.3
 Requires: quux > 1.6.9, k9 <= 2.0
 Provides: virtualeasyrpm = 0.0.1
 Conflicts: quux = 1.6.9, baz < 1.2


### PR DESCRIPTION
`Requires` can take a scriptlet argument that defines requirements for each of the scriptlets.