### PR TITLE
Support build requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,13 @@ Will add the following to the SPEC file:
 An array of packages that this package depends on (e.g.
 `["nodejs >= 0.10.22", "libpng"]`).
 
+### buildRequires
+`Array<String>`
+
+An array of packages that this package depends on to build (e.g.
+`["systemd <= 222", "libpng-devel"]`).
+
+### provides
 ### provides
 `Array<String>`
 

--- a/README.md
+++ b/README.md
@@ -417,7 +417,6 @@ An array of packages that this package depends on to build (e.g.
 `["systemd <= 222", "libpng-devel"]`).
 
 ### provides
-### provides
 `Array<String>`
 
 An array of virtual packages that this package provides.

--- a/tasks/easy_rpm.js
+++ b/tasks/easy_rpm.js
@@ -147,6 +147,9 @@ function applySpecSettings(grunt, options, spec) {
     if (_.has(options, 'requires')) {
         spec.addRequirements.apply(spec, options.requires);
     }
+    if (_.has(options, 'buildRequires')) {
+        spec.addBuildRequirements.apply(spec, options.buildRequires);
+    }
     if (_.has(options, 'provides')) {
         spec.addProvides.apply(spec, options.provides);
     }

--- a/tasks/lib/spec-writer.js
+++ b/tasks/lib/spec-writer.js
@@ -150,6 +150,9 @@ module.exports = function(spec, callback) {
     if (spec.tags.requires.length > 0) {
         buffer.add('Requires: ' + spec.tags.requires.join(', '));
     }
+    if (spec.tags.buildRequires.length > 0) {
+        buffer.add('BuildRequires: ' + spec.tags.buildRequires.join(', '));
+    }
     if (spec.tags.provides.length > 0) {
         buffer.add('Provides: ' + spec.tags.provides.join(', '));
     }

--- a/tasks/lib/spec.js
+++ b/tasks/lib/spec.js
@@ -94,6 +94,17 @@ var Spec = function() {
         // even more specific, a package's release may be included as well.
         requires: [],
 
+        // The buildRequires tag is used to alert RPM to the fact that the
+        // package needs to have certain capabilities available in order to
+        // build properly. These capabilities refer to the name of another
+        // package, or to a virtual package provided by one or more packages
+        // that use the provides tag. When the requires tag references a
+        // package name, version comparisons may also be included by following
+        // the package name with <, >, =, >=, or <=, and a version
+        // specification. To get even more specific, a package's release may be
+        // included as well.
+        buildRequires: [],
+
         // The provides tag is used to alert RPM to the fact that the package
         // will provide a virtual package.
         provides: [],
@@ -265,6 +276,10 @@ Spec.prototype.addDefines = function() {
 
 Spec.prototype.addRequirements = function() {
     this._bulkArgAdd(this.tags.requires, arguments);
+};
+
+Spec.prototype.addBuildRequirements = function() {
+    this._bulkArgAdd(this.tags.buildRequires, arguments);
 };
 
 Spec.prototype.addProvides = function() {

--- a/test/spec-writer.js
+++ b/test/spec-writer.js
@@ -84,6 +84,7 @@ describe('spec writer', function() {
             spec.tags.autoReq = false;
             spec.tags.autoProv = false;
             spec.addRequirements('quux > 1.6.9', 'k9 <= 2.0');
+            spec.addBuildRequirements('bar <= 1.2.3');
             spec.addProvides('virtualeasyrpm = 0.0.1');
             spec.addConflicts('quux = 1.6.9', 'baz < 1.2');
             spec.addExcludeArchs('sparc', 'alpha');

--- a/test/spec_writer_expected/expect_05.spec
+++ b/test/spec_writer_expected/expect_05.spec
@@ -12,6 +12,7 @@ URL: http://www.google.com/
 Group: Applications/Productivity
 Packager: Dr. Foo <foo@tardis.com>
 Requires: quux > 1.6.9, k9 <= 2.0
+BuildRequires: bar <= 1.2.3
 Provides: virtualeasyrpm = 0.0.1
 Conflicts: quux = 1.6.9, baz < 1.2
 AutoReqProv: no


### PR DESCRIPTION
`BuildRequires` defines the packages that are needed to build a program, as opposed to those that are needed to run it.