### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ grunt.initConfig({
     release: {
       files: [
         {src: '*.txt', dest: '/opt/text', cwd: 'local/text'},
-        {src: 'image/*.png', dest: '/opt'}
+        {src: 'image/*.png', dest: '/opt/image'}
       ]
     }
   }


### PR DESCRIPTION
Looks like there was a missed word in the configuration example for "Using CWD (current working directory)"